### PR TITLE
Fix code scanning alert no. 7: Unsafe jQuery plugin

### DIFF
--- a/spec/helpers/jasmine-fixture-1.0.2.js
+++ b/spec/helpers/jasmine-fixture-1.0.2.js
@@ -57,7 +57,7 @@ site: https://github.com/searls/jasmine-fixture
           parent = (context ? context : $("#" + rootId));
           $toInject = void 0;
           if (itLooksLikeHtml(arg)) {
-            $toInject = $(arg);
+            $toInject = $(jQuery.parseHTML(arg));
           } else {
             config = $.extend({}, defaults, arg, {
               userString: arg


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/chrome-ext-skeleton/security/code-scanning/7](https://github.com/cooljeanius/chrome-ext-skeleton/security/code-scanning/7)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
